### PR TITLE
Fix invalid 0777 token in script_generator.py

### DIFF
--- a/binstar_build_client/worker/utils/script_generator.py
+++ b/binstar_build_client/worker/utils/script_generator.py
@@ -191,7 +191,7 @@ def gen_build_script(build_data, **context):
         fd.write(build_script)
 
     if os.name != 'nt':
-        os.chmod(script_filename, 777)
+        os.chmod(script_filename, 0o777)
 
     return script_filename
 


### PR DESCRIPTION
Python 3 doesn't support numeric literals that start with 0.  I didn't even know this was a problem until I tried to install this with 3.4.
