### PR TITLE
ENH: added before_environment instruction

### DIFF
--- a/binstar_build_client/worker/utils/data/build_script.bat
+++ b/binstar_build_client/worker/utils/data/build_script.bat
@@ -53,12 +53,10 @@ goto:eof
 
 :main
 
-    :: echo GIT_OAUTH_TOKEN=%GIT_OAUTH_TOKEN%
-    :: echo BUILD_TARBALL=%BUILD_TARBALL%
-    :: echo BINSTAR_API_TOKEN=%BINSTAR_API_TOKEN%
-
     set BINSTAR_BUILD_RESULT=
     
+    call:bb_before_environment
+    {{check_result()}}
 
     {% if ignore_setup_build %}
     echo [ignore setup_build]
@@ -268,6 +266,8 @@ goto:eof
 {%macro check_result() -%}
 if not "%BINSTAR_BUILD_RESULT%" == "" (goto:eof)
 {%- endmacro %}
+
+{{ format_instructions('before_environment') }}
 
 {{ format_instructions('install') }}
 {{ format_instructions('test', 'failure') }}

--- a/binstar_build_client/worker/utils/data/build_script.sh
+++ b/binstar_build_client/worker/utils/data/build_script.sh
@@ -186,6 +186,9 @@ fetch_build_source(){
     {%- endif -%}
 {%- endmacro %}
 
+bb_before_environment() {
+    {{format_instructions('before_environment')}}
+}
 
 bb_install() {
     {{format_instructions('install')}}
@@ -276,6 +279,8 @@ upload_build_targets(){
 }
 
 main(){
+    
+    bb_before_environment;
     
     {% if ignore_setup_build %}
     echo "[Ignore Setup Build]"


### PR DESCRIPTION
I'm adding a before_environment instruction to be executed before all other binstar setup commands.

@cpcloud
