### PR TITLE
Fixes get_conda_root_prefix

### DIFF
--- a/binstar_build_client/utils/__init__.py
+++ b/binstar_build_client/utils/__init__.py
@@ -5,7 +5,8 @@ def get_conda_root_prefix():
     conda_ext = 'conda.exe' if os.name == 'nt' else 'conda'
 
     for entry in os.environ.get('PATH').split(os.pathsep):
-        if conda_ext in os.listdir(entry):
+
+        if os.path.isdir(entry) and conda_ext in os.listdir(entry):
             conda_exe_path = os.path.realpath(os.path.join(entry, 'conda'))
             bin_dir = os.path.dirname(conda_exe_path)
             return os.path.dirname(bin_dir)

--- a/binstar_build_client/utils/__init__.py
+++ b/binstar_build_client/utils/__init__.py
@@ -1,12 +1,14 @@
 
 
 import os
+
+CONDA_EXE = 'conda.exe' if os.name == 'nt' else 'conda'
+
 def get_conda_root_prefix():
-    conda_ext = 'conda.exe' if os.name == 'nt' else 'conda'
 
     for entry in os.environ.get('PATH').split(os.pathsep):
 
-        if os.path.isdir(entry) and conda_ext in os.listdir(entry):
+        if os.path.isdir(entry) and CONDA_EXE in os.listdir(entry):
             conda_exe_path = os.path.realpath(os.path.join(entry, 'conda'))
             bin_dir = os.path.dirname(conda_exe_path)
             return os.path.dirname(bin_dir)

--- a/binstar_build_client/utils/tests/test_conda_root_preifx.py
+++ b/binstar_build_client/utils/tests/test_conda_root_preifx.py
@@ -1,0 +1,30 @@
+'''
+Created on Feb 12, 2015
+
+@author: sean
+'''
+import unittest
+import mock
+from binstar_build_client.utils import get_conda_root_prefix, CONDA_EXE
+import os
+class Test(unittest.TestCase):
+
+    @mock.patch.dict(os.environ, {'PATH': '/does_not_exist!!'})
+    def test_path_does_not_exist(self):
+        prefix = get_conda_root_prefix()
+        self.assertIsNone(prefix)
+
+    @mock.patch.dict(os.environ, {'PATH': '/a/bin' + os.pathsep + '/b/bin'})
+    @mock.patch('os.path.isdir')
+    @mock.patch('os.listdir')
+    def test_finds_conda(self, listdir, isdir):
+        listdir.return_value = [CONDA_EXE, 'not_conda']
+        prefix = get_conda_root_prefix()
+        self.assertEqual(prefix, '/a')
+
+
+
+
+if __name__ == "__main__":
+    # import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()


### PR DESCRIPTION
This fixes the error in `get_conda_root_prefix` and adds some tests.

from #30 