### PR TITLE
Added the ability to write a statefile

### DIFF
--- a/binstar_build_client/commands/worker.py
+++ b/binstar_build_client/commands/worker.py
@@ -14,6 +14,7 @@ from binstar_client.utils import get_binstar
 import os
 from binstar_build_client.utils import get_conda_root_prefix
 from binstar_client import errors
+import time
 
 
 log = logging.getLogger('binstar.build')
@@ -39,8 +40,13 @@ def main(args):
     log.info('User: %s' % args.username)
     log.info('Queue: %s' % args.queue)
     log.info('Platform: %s' % args.platform)
-    woker = Worker(bs, args)
-    woker.work_forever()
+
+    worker = Worker(bs, args)
+    worker.write_status(True, "Starting")
+    try:
+        worker.work_forever()
+    finally:
+        worker.write_status(False, "Exited")
 
 
 OS_MAP = {'darwin': 'osx', 'windows':'win'}
@@ -113,6 +119,9 @@ def add_parser(subparsers, name='worker',
                         help='Exit main loop after only one build')
     dgroup.add_argument('--push-back', action='store_true',
                         help='Developers only, always push the build *back* onto the build queue')
+
+    dgroup.add_argument('--status-file',
+                        help='If given, binstar will update this file with the time it last checked the anaconda server for updates')
 
     parser.set_defaults(main=main)
 

--- a/binstar_build_client/worker/tests/test_worker.py
+++ b/binstar_build_client/worker/tests/test_worker.py
@@ -14,6 +14,7 @@ class MockWorker(Worker):
         args = Mock()
         args.hostname = 'test_hostname'
         args.platform = 'test_platform'
+        args.status_file = None
         args.timeout = 100
         Worker.__init__(self, bs, args)
 

--- a/binstar_build_client/worker/worker.py
+++ b/binstar_build_client/worker/worker.py
@@ -78,6 +78,11 @@ class Worker(object):
             self.worker_id = worker_id
             self._build_loop()
 
+    def write_status(self, ok=True, msg='ok'):
+        if self.args.status_file:
+            with open(self.args.status_file, 'w') as fd:
+                fd.write("%i %i '%s'\n" % (int(ok), time.time(), msg))
+
     def job_loop(self):
         """
         An iterator that will yield job_data objects when
@@ -93,7 +98,7 @@ class Worker(object):
             try:
                 job_data = bs.pop_build_job(args.username, args.queue, self.worker_id)
             except errors.NotFound:
-
+                self.write_status(False, "worker not found")
                 if args.show_traceback:
                     raise
                 else:
@@ -105,11 +110,16 @@ class Worker(object):
                 log.error("Trouble connecting to binstar at '%s' " % bs.domain)
                 log.error("Could not retrieve work items")
                 job_data = {}
+                self.write_status(False, "Trouble connecting to binstar")
+
             except errors.ServerError as err:
                 log.exception(err)
                 log.error("There server '%s' returned an error response " % bs.domain)
                 log.error("Could not retrieve work items")
+                self.write_status(False, "Server error")
                 job_data = {}
+            else:
+                self.write_status(True)
 
             if job_data.get('job') is None:
                 if not worker_idle:

--- a/binstar_build_client/worker/worker.py
+++ b/binstar_build_client/worker/worker.py
@@ -81,7 +81,7 @@ class Worker(object):
     def write_status(self, ok=True, msg='ok'):
         if self.args.status_file:
             with open(self.args.status_file, 'w') as fd:
-                fd.write("%i %i '%s'\n" % (int(ok), time.time(), msg))
+                fd.write("%i %i '%s'\n" % (int(not ok), time.time(), msg))
 
     def job_loop(self):
         """


### PR DESCRIPTION
This PR adds an option `--state-file PATH` to binstar build

The state file will be updated regularly by the binstar-build worker with the following format:
`%(status)i %(timestamp)i '%(message)s'`
Eg:

```
1 1428077284 'Trouble connecting to binstar'
```
or 

```
0 1428077284 'ok'
```

The state file should set the status to `1` on any error or exit,  and `0` when running properly.

Error conditions:
  * The status goes to `1` - you should check the logs, but the worker can still recover. 
  * The status goes to `1` for more than 2 hours - action is required.
  * The timestamp has not been updated for more than 2 hours - action is required.

cc @lilmatt @tpowellcio 
