### PR TITLE
do not allow -n root in a conda update or conda install statement

### DIFF
--- a/binstar_build_client/worker/tests/test_build_script.py
+++ b/binstar_build_client/worker/tests/test_build_script.py
@@ -297,17 +297,50 @@ class Test(unittest.TestCase):
         ok = ['conda install -n myenv numpy scipy scikit-learn',
               'conda update -n otherenv r',
               '/path/to/conda --debug update anaconda-client',
-              'conda update numpy -n rootlikename']
+              'conda update numpy -n rootlikename',
+              'conda install abc def ghi -n rootlike',
+              'conda --debug update r-root',
+              'conda install root',
+              'conda env list -n root',
+              'conda env list',
+              'conda env list -n rootlike',
+              'conda --debug install numpy',
+              'conda update conda',
+              'conda update conda-build',
+              'conda install anaconda-client',
+              'conda install roottools',
+              'conda info',
+              'someothercommand -n root'
+
+              ]
         for ok_cmd in ok:
+            self.assertEqual(ok_cmd, remove_conda_n_root(ok_cmd))
+            ok_cmd = '  ' + ok_cmd + '  '
             self.assertEqual(ok_cmd, remove_conda_n_root(ok_cmd))
         bad = ['conda --debug update -n root conda',
                ' conda    --debug    update     -n     root    conda  ',
                'conda install something -n root',
-               'conda install something -n root ',
                'conda --debug install conda-build -n root',
-               '/path/to/conda   --debug    install    conda-build   -n   root  ']
+               '/path/to/conda   --debug    install    conda-build   -n   root  ',
+               'conda install -c abc/def -n root conda-build conda',
+              ' conda update -c http://domain.com/path -n root',
+              '/path/to/conda --debug update abc def ghi -n root',
+              'conda install abc def ghi -n root']
         for bad_cmd in bad:
             self.assertIn('NOT RUNNING', remove_conda_n_root(bad_cmd))
+            bad_cmd = bad_cmd.replace('-n', '--name')
+            self.assertIn('NOT RUNNING', remove_conda_n_root(bad_cmd))
+        for ok_cmd in ok:
+            if not 'update' in ok_cmd or not 'install' in ok_cmd:
+                continue
+            if not 'conda' in ok_cmd:
+                continue
+            bad_cmd = ok_cmd + '     -n root'
+            self.assertNotEqual(bad_cmd, remove_conda_n_root(bad_cmd))
+            bad_cmd = ' ' + bad_cmd + ' '
+            self.assertNotEqual(bad_cmd, remove_conda_n_root(bad_cmd))
+            bad_cmd = bad_cmd.replace('-n root', '--name   root')
+            self.assertNotEqual(bad_cmd, remove_conda_n_root(bad_cmd))
 
 if __name__ == "__main__":
     # import sys;sys.argv = ['', 'Test.test_timeout']

--- a/binstar_build_client/worker/utils/script_generator.py
+++ b/binstar_build_client/worker/utils/script_generator.py
@@ -29,11 +29,10 @@ EXIT_CODE_OK = 0
 EXIT_CODE_ERROR = 11
 EXIT_CODE_FAILED = 12
 
-AVOID_CONDA_UPDATE_N_ROOT = re.compile('conda\s+(--debug\s+){0,1}'
-                                       '((install)|(update)){1}\s+'
-                                       '[\. "\'\\/.-]*-n\s+root\s+|$')
-
-# ===============================================================================
+AVOID_N_ROOT_1 = re.compile('conda\s+(--debug\s+){0,1}'
+                                       '((install)|(update)){1}\s+')
+AVOID_N_ROOT_2 = re.compile('\s+\-n\s+root(?!\w)(?!\d)')
+AVOID_N_ROOT_3 = re.compile('\s+\-\-name\s+root(?!\w)(?!\d)')
 # Helper functions
 # ===============================================================================
 
@@ -187,9 +186,12 @@ def remove_conda_n_root(build_script):
     lines = []
     comment = 'REM ######## ' if os.name == 'nt' else '########  '
     for line in build_script.split('\n'):
-        if bool(re.search(AVOID_CONDA_UPDATE_N_ROOT, line)):
-            lines.extend(('{} NOT RUNNING: {}'.format(comment, line),
-                          '{} (It is updating conda root env)'.format(comment)))
+        if bool(re.search(AVOID_N_ROOT_1, line)):
+            if bool(re.search(AVOID_N_ROOT_2, line)) or bool(re.search(AVOID_N_ROOT_3, line)):
+                lines.extend(('{} NOT RUNNING: {}'.format(comment, line),
+                              '{} (It is updating conda root env)'.format(comment)))
+            else:
+                lines.append(line)
         else:
             lines.append(line)
     return '\n'.join(lines)


### PR DESCRIPTION
This PR redacts statements like `conda update -n root conda-build`.  The more permanent solution is the usage of docker workers or virtualization.
