### PR TITLE
Only fallback to old log endpoint on 404

### DIFF
--- a/binstar_build_client/mixins/build_queue.py
+++ b/binstar_build_client/mixins/build_queue.py
@@ -75,6 +75,11 @@ class BuildQueueMixin(object):
         try:
             self._check_response(res, [201, 200])
         except errors.NotFound:
+            if hasattr(self, 'log_build_output_structured_failed'):
+                # it might be a missing build or job that's not found.
+                # structured log has succeeded at least once, so don't give up!
+                raise
+
             log.info('Will not attempt structured '
                      'logging with tags, falling back '
                      'to plain build log.  There is no '
@@ -83,6 +88,8 @@ class BuildQueueMixin(object):
             return self.log_build_output(username, queue_name,
                                   worker_id, job_id,
                                   msg)
+        else:
+            self.log_build_output_structured_failed = False
 
         try:
             result = res.json().get('terminate_build', False)

--- a/binstar_build_client/mixins/build_queue.py
+++ b/binstar_build_client/mixins/build_queue.py
@@ -74,11 +74,11 @@ class BuildQueueMixin(object):
         res = self.session.post(url, data=content)
         try:
             self._check_response(res, [201, 200])
-        except Exception as e:
+        except errors.NotFound:
             log.info('Will not attempt structured '
                      'logging with tags, falling back '
                      'to plain build log.  There is no '
-                     'Repository endpoint ' + url)
+                     'Repository endpoint %s', url, exc_info=True)
             self.log_build_output_structured_failed = True
             return self.log_build_output(username, queue_name,
                                   worker_id, job_id,

--- a/binstar_build_client/worker/tests/test_build_log.py
+++ b/binstar_build_client/worker/tests/test_build_log.py
@@ -217,24 +217,19 @@ class TestServer(unittest.TestCase):
     @mock.patch('binstar_build_client.worker.utils.build_log.MAX_WRITE_ATTEMPTS', 2)
     @urlmock.urlpatch
     def test_terminate_server_error(self, urls):
-        urls.register(
+        log_tagged = urls.register(
             method='POST',
             path='/build-worker/user_name/queue_name/worker_id/jobs/123/tagged-log',
-            status=500,
-        )
-        log_simple = urls.register(
-            method='POST',
-            path='/build-worker/user_name/queue_name/worker_id/jobs/123/log',
             status=500,
         )
 
         with mk_log(filename=self.filepath) as log:
             log.writeline(b'This is some data\n')
             log.flush()
-            self.assertEqual(len(log_simple._resps), 1)
+            self.assertEqual(len(log_tagged._resps), 1)
             self.assertFalse(log.terminated(), "Should not terminate after the first failure")
             log.flush()
-            self.assertEqual(len(log_simple._resps), 2)
+            self.assertEqual(len(log_tagged._resps), 2)
             self.assertTrue(log.terminated(), "Should terminate after MAX_WRITE_ATTEMPTS")
 
 

--- a/binstar_build_client/worker/tests/test_build_log.py
+++ b/binstar_build_client/worker/tests/test_build_log.py
@@ -214,6 +214,39 @@ class TestServer(unittest.TestCase):
 
         urls.assertAllCalled()
 
+    @urlmock.urlpatch
+    def test_after_success_does_not_fall_back(self, urls):
+        log_tagged = urls.register(
+            method='POST',
+            path='/build-worker/user_name/queue_name/worker_id/jobs/123/tagged-log',
+            status=200,
+        )
+        log_simple = urls.register(
+            method='POST',
+            path='/build-worker/user_name/queue_name/worker_id/jobs/123/log',
+            status=200,
+        )
+
+        with mk_log(filename=self.filepath) as log:
+            log.writeline(b'This is some data\n')
+            log.flush()
+
+            self.assertEqual(len(log_tagged._resps), 1)
+            self.assertEqual(len(log_simple._resps), 0)
+
+            log_tagged = urls.register(
+                method='POST',
+                path='/build-worker/user_name/queue_name/worker_id/jobs/123/tagged-log',
+                status=404,
+            )
+
+            log.writeline(b'This is some later data\n')
+            log.flush()
+
+            self.assertEqual(len(log_tagged._resps), 1)
+            self.assertEqual(len(log_simple._resps), 0)
+
+
     @mock.patch('binstar_build_client.worker.utils.build_log.MAX_WRITE_ATTEMPTS', 2)
     @urlmock.urlpatch
     def test_terminate_server_error(self, urls):


### PR DESCRIPTION
Fixes #276 

Only `NotFound` should cause changing to the old format. Once structured succeeds, should not fall back again.
